### PR TITLE
Allow clients to specify output scripts in proposals

### DIFF
--- a/lib/walletutils.js
+++ b/lib/walletutils.js
@@ -192,7 +192,14 @@ WalletUtils.buildTx = function(txp) {
     t.to(txp.toAddress, txp.amount);
   } else if (txp.outputs) {
     _.each(txp.outputs, function(o) {
-      t.to(o.toAddress, o.amount);
+      if (o.script) {
+        t.addOutput(new Bitcore.Transaction.Output({
+          script: o.script,
+          satoshis: o.amount
+        }));
+      } else {
+        t.to(o.toAddress, o.amount);
+      }
     });
   }
 

--- a/lib/walletutils.js
+++ b/lib/walletutils.js
@@ -188,7 +188,7 @@ WalletUtils.buildTx = function(txp) {
     t.from(i, i.publicKeys, txp.requiredSignatures);
   });
 
-  if (txp.toAddress && txp.amount) {
+  if (txp.toAddress && txp.amount && !txp.outputs) {
     t.to(txp.toAddress, txp.amount);
   } else if (txp.outputs) {
     _.each(txp.outputs, function(o) {

--- a/lib/walletutils.js
+++ b/lib/walletutils.js
@@ -192,6 +192,7 @@ WalletUtils.buildTx = function(txp) {
     t.to(txp.toAddress, txp.amount);
   } else if (txp.outputs) {
     _.each(txp.outputs, function(o) {
+      $.checkState(!o.script != !o.toAddress, 'Output should have either toAddress or script specified');
       if (o.script) {
         t.addOutput(new Bitcore.Transaction.Output({
           script: o.script,

--- a/lib/walletutils.js
+++ b/lib/walletutils.js
@@ -237,9 +237,9 @@ WalletUtils.buildTx = function(txp) {
 
 WalletUtils.signTxp = function(txp, xPrivKey) {
   var self = this;
+
   $.checkArgument(txp);
   $.checkArgument(xPrivKey);
-  $.checkArgument(txp.toAddress || (txp.outputs && txp.outputs[0].toAddress), 'toAddress is invalid');
   $.checkArgument(txp.amount || (txp.outputs && txp.outputs[0].amount), 'amount is invalid');
   $.checkArgument(txp.changeAddress && txp.changeAddress.address, 'changeAddress is invalid');
 
@@ -248,8 +248,7 @@ WalletUtils.signTxp = function(txp, xPrivKey) {
   var privs = [];
   var derived = {};
 
-  var toAddress = txp.toAddress || txp.outputs[0].toAddress;
-  var network = new Bitcore.Address(toAddress).network.name;
+  var network = new Bitcore.Address(txp.changeAddress.address).network.name;
   var xpriv = new Bitcore.HDPrivateKey(xPrivKey, network).derive(WalletUtils.PATHS.BASE_ADDRESS_DERIVATION);
 
   _.each(txp.inputs, function(i) {

--- a/test/walletutils.js
+++ b/test/walletutils.js
@@ -405,7 +405,6 @@ describe('WalletUtils', function() {
         type: 'external',
         outputs: [
           {
-            "toAddress":"18433T2TSgajt9jWhcTBw4GoNREA6LpX3E",
             "amount":700,
             "script":"512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae"
           },
@@ -439,6 +438,54 @@ describe('WalletUtils', function() {
       t.outputs[2].satoshis.should.equal(txp.outputs[2].amount);
       var changeScript = Bitcore.Script.fromAddress(txp.changeAddress.address).toHex();
       t.outputs[3].script.toHex().should.equal(changeScript);
+    });
+    it('should fail if provided output has both toAddress and script', function() {
+      var hdPrivateKey = new Bitcore.HDPrivateKey('tprv8ZgxMBicQKsPdPLE72pfSo7CvzTsWddGHdwSuMNrcerr8yQZKdaPXiRtP9Ew8ueSe9M7jS6RJsp4DiAVS2xmyxcCC9kZV6X1FMsX7EQX2R5');
+      var derivedPrivateKey = hdPrivateKey.derive(WalletUtils.PATHS.BASE_ADDRESS_DERIVATION);
+
+      var toAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
+      var changeAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
+
+      var publicKeyRing = [{
+        xPubKey: new Bitcore.HDPublicKey(derivedPrivateKey)
+      }];
+
+      var utxos = helpers.generateUtxos(publicKeyRing, 'm/1/0', 1, [0.001]);
+      var txp = {
+        inputs: utxos,
+        type: 'external',
+        outputs: [
+          {
+            "toAddress":"18433T2TSgajt9jWhcTBw4GoNREA6LpX3E",
+            "amount":700,
+            "script":"512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae"
+          },
+          {
+            "amount":600,
+            "script":"76a9144d5bd54809f846dc6b1a14cbdd0ac87a3c66f76688ac"
+          },
+          {
+            "amount":0,
+            "script":"6a1e43430102fa9213bc243af03857d0f9165e971153586d3915201201201210"
+          }
+        ],
+        changeAddress: {
+          address: changeAddress
+        },
+        requiredSignatures: 1,
+        outputOrder: [0, 1, 2, 3],
+        fee: 10000,
+      };
+      (function() {
+        var t = WalletUtils.buildTx(txp);
+      }).should.throw('Output should have either toAddress or script specified');
+
+      delete txp.outputs[0].toAddress;
+      var t = WalletUtils.buildTx(txp);
+      var bitcoreError = t.getSerializationError({
+        disableIsFullySigned: true,
+      });
+      should.not.exist(bitcoreError);
     });
 
   });
@@ -527,7 +574,6 @@ describe('WalletUtils', function() {
             "script":"512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae"
           },
           {
-            "toAddress":"18433T2TSgajt9jWhcTBw4GoNREA6LpX3E",
             "amount":600,
             "script":"76a9144d5bd54809f846dc6b1a14cbdd0ac87a3c66f76688ac"
           },

--- a/test/walletutils.js
+++ b/test/walletutils.js
@@ -497,6 +497,46 @@ describe('WalletUtils', function() {
       var signatures = WalletUtils.signTxp(txp, hdPrivateKey);
       signatures.length.should.be.equal(utxos.length);
     });
+    it('should sign proposal with provided output scripts correctly', function() {
+      var hdPrivateKey = new Bitcore.HDPrivateKey('tprv8ZgxMBicQKsPdPLE72pfSo7CvzTsWddGHdwSuMNrcerr8yQZKdaPXiRtP9Ew8ueSe9M7jS6RJsp4DiAVS2xmyxcCC9kZV6X1FMsX7EQX2R5');
+      var derivedPrivateKey = hdPrivateKey.derive(WalletUtils.PATHS.BASE_ADDRESS_DERIVATION);
+
+      var toAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
+      var changeAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
+
+      var publicKeyRing = [{
+        xPubKey: new Bitcore.HDPublicKey(derivedPrivateKey)
+      }];
+
+      var utxos = helpers.generateUtxos(publicKeyRing, 'm/1/0', 1, [0.001]);
+      var txp = {
+        inputs: utxos,
+        type: 'external',
+        outputs: [
+          {
+            "amount":700,
+            "script":"512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae"
+          },
+          {
+            "toAddress":"18433T2TSgajt9jWhcTBw4GoNREA6LpX3E",
+            "amount":600,
+            "script":"76a9144d5bd54809f846dc6b1a14cbdd0ac87a3c66f76688ac"
+          },
+          {
+            "amount":0,
+            "script":"6a1e43430102fa9213bc243af03857d0f9165e971153586d3915201201201210"
+          }
+        ],
+        changeAddress: {
+          address: changeAddress
+        },
+        requiredSignatures: 1,
+        outputOrder: [0, 1, 2, 3],
+        fee: 10000,
+      };
+      var signatures = WalletUtils.signTxp(txp, hdPrivateKey);
+      signatures.length.should.be.equal(utxos.length);
+    });
   });
 
   describe('#formatAmount', function() {

--- a/test/walletutils.js
+++ b/test/walletutils.js
@@ -405,11 +405,11 @@ describe('WalletUtils', function() {
         type: 'external',
         outputs: [
           {
+            "toAddress":"18433T2TSgajt9jWhcTBw4GoNREA6LpX3E",
             "amount":700,
             "script":"512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae"
           },
           {
-            "toAddress":"18433T2TSgajt9jWhcTBw4GoNREA6LpX3E",
             "amount":600,
             "script":"76a9144d5bd54809f846dc6b1a14cbdd0ac87a3c66f76688ac"
           },
@@ -430,6 +430,15 @@ describe('WalletUtils', function() {
         disableIsFullySigned: true,
       });
       should.not.exist(bitcoreError);
+      t.outputs.length.should.equal(4);
+      t.outputs[0].script.toHex().should.equal(txp.outputs[0].script);
+      t.outputs[0].satoshis.should.equal(txp.outputs[0].amount);
+      t.outputs[1].script.toHex().should.equal(txp.outputs[1].script);
+      t.outputs[1].satoshis.should.equal(txp.outputs[1].amount);
+      t.outputs[2].script.toHex().should.equal(txp.outputs[2].script);
+      t.outputs[2].satoshis.should.equal(txp.outputs[2].amount);
+      var changeScript = Bitcore.Script.fromAddress(txp.changeAddress.address).toHex();
+      t.outputs[3].script.toHex().should.equal(changeScript);
     });
 
   });


### PR DESCRIPTION
This will allow to create proposal with arbitrary output types (e.g. OP_RETURN or OP_CHECKMULTISIG). To do that ``script`` property should be specified for output.

Usage example is colored coins integration (work in progress)