### PR TITLE
Changed to use semvar caret ranges for bitcore patch compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/bitpay/bitcore-wallet-utils/issues"
   },
   "dependencies": {
-    "bitcore": "0.13.0",
+    "bitcore": "^0.13.0",
     "coveralls": "^2.11.2",
     "json-stable-stringify": "^1.0.0",
     "lodash": "^3.3.1",


### PR DESCRIPTION
Any patch releases will be compatible, and should avoid issues where multiple version of bitcore are installed.

See: https://github.com/npm/node-semver#caret-ranges-123-025-004